### PR TITLE
Set "validate_certs: yes" everywhere.

### DIFF
--- a/roles/ecs/tasks/main.yml
+++ b/roles/ecs/tasks/main.yml
@@ -5,7 +5,7 @@
     url: "{{ AUTH_URL_ECS }}"
     method: GET
     return_content: yes 
-    validate_certs: no
+    validate_certs: yes
     HEADER_Content-Type: "application/json"
     HEADER_X-Auth-Token: "{{ token['x_subject_token'] }}"
   register: ecslist

--- a/roles/flavors/tasks/main.yml
+++ b/roles/flavors/tasks/main.yml
@@ -3,7 +3,7 @@
     url: "{{ AUTH_URL_FLAVORS }}"
     method: GET
     return_content: yes 
-    validate_certs: no
+    validate_certs: yes
     HEADER_Content-Type: "application/json"
     HEADER_X-Auth-Token: "{{ token['x_subject_token'] }}"
   register: flavorlist

--- a/roles/floatingip/tasks/main.yml
+++ b/roles/floatingip/tasks/main.yml
@@ -3,7 +3,7 @@
     url: "{{ AUTH_URL_PUBLICIPS }}"
     method: GET
     return_content: yes 
-    validate_certs: no
+    validate_certs: yes
     HEADER_Content-Type: "application/json"
     HEADER_X-Auth-Token: "{{ token['x_subject_token'] }}"
   register: floatingiplist

--- a/roles/images/tasks/main.yml
+++ b/roles/images/tasks/main.yml
@@ -3,7 +3,7 @@
     url: "{{ AUTH_URL_IMAGES }}"
     method: GET
     return_content: yes 
-    validate_certs: no
+    validate_certs: yes
     HEADER_Content-Type: "application/json"
     HEADER_X-Auth-Token: "{{ token['x_subject_token'] }}"
   register: imageslist

--- a/roles/secgroups/tasks/main.yml
+++ b/roles/secgroups/tasks/main.yml
@@ -3,7 +3,7 @@
     url: "{{ AUTH_URL_SEC_GROUPS }}"
     method: GET
     return_content: yes 
-    validate_certs: no
+    validate_certs: yes
     HEADER_Content-Type: "application/json"
     HEADER_X-Auth-Token: "{{ token['x_subject_token'] }}"
   register: secgrouplist

--- a/roles/subnet/tasks/main.yml
+++ b/roles/subnet/tasks/main.yml
@@ -3,7 +3,7 @@
     url: "{{ AUTH_URL_SUBNETS }}"
     method: GET
     return_content: yes 
-    validate_certs: no
+    validate_certs: yes
     HEADER_Content-Type: "application/json"
     HEADER_X-Auth-Token: "{{ token['x_subject_token'] }}"
   register: subnetlist

--- a/roles/token/tasks/main.yml
+++ b/roles/token/tasks/main.yml
@@ -8,7 +8,7 @@
     follow_redirects: all
     status_code: 201
     return_content: yes 
-    validate_certs: no
+    validate_certs: yes
     HEADER_Content-Type: "application/json"
     body: "{{ lookup('template', 'roles/token/templates/request.json.j2',convert_data=True)|to_json }}" 
   register: token

--- a/roles/vm/tasks/main.yml
+++ b/roles/vm/tasks/main.yml
@@ -7,7 +7,7 @@
     body_format: raw
     follow_redirects: all
     return_content: yes 
-    validate_certs: no
+    validate_certs: yes
     HEADER_Content-Type: "application/json"
     HEADER_X-Auth-Token: "{{ token['x_subject_token'] }}"
     body: "{{ lookup('template', 'roles/vm/templates/request.json.j2')|to_json }}" 

--- a/roles/vpc/tasks/main.yml
+++ b/roles/vpc/tasks/main.yml
@@ -3,7 +3,7 @@
     url: "{{ AUTH_URL_VPCS }}"
     method: GET
     return_content: yes 
-    validate_certs: no
+    validate_certs: yes
     HEADER_Content-Type: "application/json"
     HEADER_X-Auth-Token: "{{ token['x_subject_token'] }}"
   register: vpclist


### PR DESCRIPTION
The API gateway had failed to publish an intermediate cert, so the
trust chain could not be validated successfully before.
This has been fixed meanwhile, so there is no need to set
"validate_certs: no" any longer.
